### PR TITLE
Register SimpleCorsFilter in HTTP filter chain

### DIFF
--- a/src/main/java/net/maritimeconnectivity/serviceregistry/config/SimpleCorsFilter.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/config/SimpleCorsFilter.java
@@ -19,7 +19,6 @@
 package net.maritimeconnectivity.serviceregistry.config;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
@@ -31,7 +30,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-@Component
 @Slf4j
 public class SimpleCorsFilter implements Filter {
 

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/config/SpringSecurityConfig.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/config/SpringSecurityConfig.java
@@ -42,6 +42,7 @@ import org.springframework.security.core.session.SessionRegistryImpl;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.channel.ChannelProcessingFilter;
 import org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy;
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 import org.springframework.security.web.firewall.HttpFirewall;
@@ -176,6 +177,8 @@ class SpringSecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http,
                                            ClientRegistrationRepository clientRegistrationRepository,
                                            RestTemplate restTemplate) throws Exception {
+        // Register the CORS preflight filter
+        http.addFilterBefore(new SimpleCorsFilter(), ChannelProcessingFilter.class);
         // Authenticate through configured OpenID Provider
         http.oauth2Login(login -> login
                 .loginPage("/oauth2/authorization/keycloak")


### PR DESCRIPTION
For some reason we now need to register the filter manually instead of having it injected using the `@Component` annotation.
Without this CORS preflight request using HTTP OPTIONS won't work.